### PR TITLE
Updated pinned Ruby from 2.6.0 -> 2.6.9 to support M1 and Xcode 14.

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -113,7 +113,7 @@ workflows:
             #!/bin/bash
             set -ex
 
-            echo "2.6.0" >> .ruby-version
+            echo "2.6.9" >> .ruby-version
     - path::./:
         inputs:
         - source_root_path: $BITRISE_SOURCE_DIR/_tmp


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->
Unified CI is [failing](https://app.bitrise.io/build/16f904c1-d7fb-407e-b4fb-29d74c06acee) when run against the latest Xcode 14 beta. 
### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->
Seems like Ruby 2.6.0 is not installable on M1, and this version is technically [EOL](https://endoflife.software/programming-languages/server-side-scripting/ruby)

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
