### PR TITLE
Update go-steputils for asdf support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module bitrise-steplib/steps-cocoapods-install
 go 1.15
 
 require (
-	github.com/bitrise-io/go-steputils v1.0.2
+	github.com/bitrise-io/go-steputils v1.0.4
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-xcode v1.0.3
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 h1:/2OyBFI7GjYKexBPcfTPvKFz8Ks7qYzkkz2SQ8aiJgc=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10/go.mod h1:pARutiL3kEuRLV3JvswidvfCj+9Y3qMZtji2BDqLFsA=
 github.com/bitrise-io/go-steputils v1.0.1/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
-github.com/bitrise-io/go-steputils v1.0.2 h1:BEFG87r7uA/Yabk4SmuxP2yOgjjO+YGsDOYXtUH8IJ0=
-github.com/bitrise-io/go-steputils v1.0.2/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
+github.com/bitrise-io/go-steputils v1.0.4 h1:x2nYKobj8U36tK7O72cZrbBh9/mAVL2Ka1yKVWAEcIM=
+github.com/bitrise-io/go-steputils v1.0.4/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
 github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74zzcvk=
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-xcode v1.0.3 h1:uj9Yx62szJ9zGKTLuPaS0k1E9ldtCiOm17wivi5u9+4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10
 github.com/bitrise-io/go-plist
-# github.com/bitrise-io/go-steputils v1.0.2
+# github.com/bitrise-io/go-steputils v1.0.4
 ## explicit
 github.com/bitrise-io/go-steputils/cache
 github.com/bitrise-io/go-steputils/command/gems


### PR DESCRIPTION
Now that https://github.com/bitrise-io/go-steputils/pull/71 has been merged, and [go-steputils v1.0.4](https://github.com/bitrise-io/go-steputils/releases/tag/v1.0.4) has been released, this is ready to be reviewed.

### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

I'm trying to work on this Step on my computer, but I use `asdf` to manage Ruby versions, and currently the Step throws errors when trying to run. I'd like to be able to run it while using asdf on my machine.

### Changes

- Updates go-steputils to a version that supports asdf