### PR TITLE
Modernize E2E tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -9,43 +9,22 @@ app:
   - PIN_RUBY: "false"
 
 workflows:
-#  test_with_no_podfile_lock:
-#    envs:
-#    # With Only Gemfile (no Podfile.lock):
-#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-#    - TEST_APP_BRANCH: no-podfile-lock
-#    - COMMAND: install
-#    after_run:
-#    - _run
-#    - _check_cache_include_paths
-
-#  test_update_with_gemfile:
-#    envs:
-#    # With Gemfile:
-#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-#    - TEST_APP_BRANCH: master
-#    - COMMAND: update
-#    after_run:
-#    - _run
-#    - _check_cache_include_paths
-#
-#  test_without_gemfile:
-#    envs:
-#    # Without Gemfile:
-#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
-#    - TEST_APP_BRANCH: master
-#    - COMMAND: install
-#    after_run:
-#    - _run
-#    - _check_cache_include_paths
-#
-  test_without_gemfile_with_podfile_path:
+  test_with_no_podfile_lock:
     envs:
-    # Without Gemfile:
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
-    - TEST_APP_BRANCH: master
-    - PODFILE_PTH: CocoaPods1X/Podfile
+    # With Only Gemfile (no Podfile.lock):
+    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+    - TEST_APP_BRANCH: no-podfile-lock
     - COMMAND: install
+    after_run:
+    - _run
+    - _check_cache_include_paths
+
+  test_update_with_gemfile:
+    envs:
+    # With Gemfile:
+    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+    - TEST_APP_BRANCH: master
+    - COMMAND: update
     after_run:
     - _run
     - _check_cache_include_paths

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -9,11 +9,20 @@ app:
   - PIN_RUBY: "false"
 
 workflows:
+  test_no_gemfile:
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
+    - TEST_APP_BRANCH: e2e/podfile-lock-no-gemfile
+    - COMMAND: install
+    after_run:
+    - _run
+    - _check_cache_include_paths
+
   test_with_no_podfile_lock:
     envs:
     # With Only Gemfile (no Podfile.lock):
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: no-podfile-lock
+    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
+    - TEST_APP_BRANCH: e2e/gemfile-no-podfile-lock
     - COMMAND: install
     after_run:
     - _run
@@ -22,8 +31,8 @@ workflows:
   test_update_with_gemfile:
     envs:
     # With Gemfile:
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
+    - TEST_APP_BRANCH: e2e/gemfile-podfile-lockfiles
     - COMMAND: update
     after_run:
     - _run
@@ -32,8 +41,8 @@ workflows:
   test_with_verbose:
     envs:
     # With Gemfile:
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
+    - TEST_APP_BRANCH: main
     - COMMAND: install
     - VERBOSE: "true"
     after_run:
@@ -43,8 +52,8 @@ workflows:
   test_with_specific_ruby:
     envs:
     # Podfile is in repo root
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
+    - TEST_APP_BRANCH: main
     - COMMAND: install
     - PIN_RUBY: "true"
     after_run:
@@ -56,15 +65,6 @@ workflows:
     # With Gemfile:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-apps-ios-cocoapods-plugins.git
     - TEST_APP_BRANCH: master
-    - COMMAND: install
-    after_run:
-    - _run
-    - _check_cache_include_paths
-
-  test_recent_cocoapods:
-    envs:
-    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
-    - TEST_APP_BRANCH: main
     - COMMAND: install
     after_run:
     - _run
@@ -99,7 +99,7 @@ workflows:
             #!/bin/bash
             set -ex
 
-            echo "2.6.9" >> .ruby-version
+            echo "3.1.0" >> .ruby-version
     - path::./:
         inputs:
         - source_root_path: $BITRISE_SOURCE_DIR/_tmp

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -9,68 +9,68 @@ app:
   - PIN_RUBY: "false"
 
 workflows:
-  test_with_no_podfile_lock:
-    envs:
-    # With Only Gemfile (no Podfile.lock):
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: no-podfile-lock
-    - COMMAND: install
-    after_run:
-    - _run
-    - _check_cache_include_paths
+#  test_with_no_podfile_lock:
+#    envs:
+#    # With Only Gemfile (no Podfile.lock):
+#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+#    - TEST_APP_BRANCH: no-podfile-lock
+#    - COMMAND: install
+#    after_run:
+#    - _run
+#    - _check_cache_include_paths
 
-  test_update_with_gemfile:
-    envs:
-    # With Gemfile:
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: master
-    - COMMAND: update
-    after_run:
-    - _run
-    - _check_cache_include_paths
-
-  test_without_gemfile:
-    envs:
-    # Without Gemfile:
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
-    - TEST_APP_BRANCH: master
-    - COMMAND: install
-    after_run:
-    - _run
-    - _check_cache_include_paths
-
-  test_without_gemfile_with_podfile_path:
-    envs:
-    # Without Gemfile:
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
-    - TEST_APP_BRANCH: master
-    - PODFILE_PTH: CocoaPods1X/Podfile
-    - COMMAND: install
-    after_run:
-    - _run
-    - _check_cache_include_paths
-
-  test_with_verbose:
-    envs:
-    # With Gemfile:
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: master
-    - COMMAND: install
-    - VERBOSE: "true"
-    after_run:
-    - _run
-    - _check_cache_include_paths
-
-  test_with_specific_ruby:
-    envs:
-    # Podfile is in repo root
-    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-    - TEST_APP_BRANCH: master
-    - COMMAND: install
-    - PIN_RUBY: "true"
-    after_run:
-    - _run
-    - _check_cache_include_paths
+#  test_update_with_gemfile:
+#    envs:
+#    # With Gemfile:
+#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+#    - TEST_APP_BRANCH: master
+#    - COMMAND: update
+#    after_run:
+#    - _run
+#    - _check_cache_include_paths
+#
+#  test_without_gemfile:
+#    envs:
+#    # Without Gemfile:
+#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
+#    - TEST_APP_BRANCH: master
+#    - COMMAND: install
+#    after_run:
+#    - _run
+#    - _check_cache_include_paths
+#
+#  test_without_gemfile_with_podfile_path:
+#    envs:
+#    # Without Gemfile:
+#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
+#    - TEST_APP_BRANCH: master
+#    - PODFILE_PTH: CocoaPods1X/Podfile
+#    - COMMAND: install
+#    after_run:
+#    - _run
+#    - _check_cache_include_paths
+#
+#  test_with_verbose:
+#    envs:
+#    # With Gemfile:
+#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+#    - TEST_APP_BRANCH: master
+#    - COMMAND: install
+#    - VERBOSE: "true"
+#    after_run:
+#    - _run
+#    - _check_cache_include_paths
+#
+#  test_with_specific_ruby:
+#    envs:
+#    # Podfile is in repo root
+#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+#    - TEST_APP_BRANCH: master
+#    - COMMAND: install
+#    - PIN_RUBY: "true"
+#    after_run:
+#    - _run
+#    - _check_cache_include_paths
 
   test_with_plugins:
     envs:
@@ -99,6 +99,13 @@ workflows:
             #!/bin/bash
             set -ex
             rm -rf ./_tmp
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            rbenv uninstall -f 2.7.6
+            rbenv global 3.2.1
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -39,28 +39,28 @@ workflows:
 #    - _run
 #    - _check_cache_include_paths
 #
-#  test_without_gemfile_with_podfile_path:
-#    envs:
-#    # Without Gemfile:
-#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
-#    - TEST_APP_BRANCH: master
-#    - PODFILE_PTH: CocoaPods1X/Podfile
-#    - COMMAND: install
-#    after_run:
-#    - _run
-#    - _check_cache_include_paths
-#
-#  test_with_verbose:
-#    envs:
-#    # With Gemfile:
-#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-#    - TEST_APP_BRANCH: master
-#    - COMMAND: install
-#    - VERBOSE: "true"
-#    after_run:
-#    - _run
-#    - _check_cache_include_paths
-#
+  test_without_gemfile_with_podfile_path:
+    envs:
+    # Without Gemfile:
+    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x.git
+    - TEST_APP_BRANCH: master
+    - PODFILE_PTH: CocoaPods1X/Podfile
+    - COMMAND: install
+    after_run:
+    - _run
+    - _check_cache_include_paths
+
+  test_with_verbose:
+    envs:
+    # With Gemfile:
+    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+    - TEST_APP_BRANCH: master
+    - COMMAND: install
+    - VERBOSE: "true"
+    after_run:
+    - _run
+    - _check_cache_include_paths
+
   test_with_specific_ruby:
     envs:
     # Podfile is in repo root

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -78,13 +78,6 @@ workflows:
             #!/bin/bash
             set -ex
             rm -rf ./_tmp
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            rbenv uninstall -f 2.7.6
-            rbenv global 3.2.1
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -51,7 +51,6 @@ workflows:
 
   test_with_specific_ruby:
     envs:
-    # Podfile is in repo root
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
     - TEST_APP_BRANCH: main
     - COMMAND: install
@@ -92,7 +91,7 @@ workflows:
             #!/bin/bash
             set -ex
 
-            echo "3.1.0" >> .ruby-version
+            echo "3.1.3" >> .ruby-version
     - path::./:
         inputs:
         - source_root_path: $BITRISE_SOURCE_DIR/_tmp

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -61,16 +61,16 @@ workflows:
 #    - _run
 #    - _check_cache_include_paths
 #
-#  test_with_specific_ruby:
-#    envs:
-#    # Podfile is in repo root
-#    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
-#    - TEST_APP_BRANCH: master
-#    - COMMAND: install
-#    - PIN_RUBY: "true"
-#    after_run:
-#    - _run
-#    - _check_cache_include_paths
+  test_with_specific_ruby:
+    envs:
+    # Podfile is in repo root
+    - TEST_APP_URL: https://github.com/bitrise-io/ios-cocoapods-1.x-Gemfile.git
+    - TEST_APP_BRANCH: master
+    - COMMAND: install
+    - PIN_RUBY: "true"
+    after_run:
+    - _run
+    - _check_cache_include_paths
 
   test_with_plugins:
     envs:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *NO* [version update](https://semver.org/)

### Context

Some E2E tests were using 5 year old sample apps. This made the tests incompatible with newer Ruby version, and upgrading the projects turned out to be harder than switching to more recent sample apps we already have.

### Changes

Make all tests use the https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git sample project's different branches.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
