### PR TITLE
Add annotation for specs repo users

### DIFF
--- a/main.go
+++ b/main.go
@@ -269,6 +269,9 @@ func main() {
 	if err != nil {
 		log.Warnf("Failed to determine if Podfile is using Specs repo, error: %s", err)
 	} else {
+		if isUsingSpecsRepo {
+			addSpecsRepoAnnotation(cmdFactory)
+		}
 		tracker.Enqueue("step_cocoapods_install_podfile_used", analytics.Properties{
 			"step_execution_id":   envRepository.Get("BITRISE_STEP_EXECUTION_ID"),
 			"build_slug":          envRepository.Get("BITRISE_BUILD_SLUG"),

--- a/podfile.go
+++ b/podfile.go
@@ -9,8 +9,9 @@ import (
 )
 
 const specsRepoWarning = `### CocoaPods tip
-Your Podfile is still using the Specs repo. Switch to the CDN source for faster and more reliable dependency installs!
-Learn more about the one-line change [here](https://blog.cocoapods.org/CocoaPods-1.8.0-beta/).
+Your Podfile is still using the Specs repo. Switch to the CDN source for **faster and more reliable** dependency installs!
+
+Learn more about the **one-line change** [here](https://blog.cocoapods.org/CocoaPods-1.8.0-beta/).
 `
 
 // isPodfileUsingSpecsRepo returns true if the Podfile contains a source 'https://github.com/CocoaPods/Specs.git'.

--- a/podfile.go
+++ b/podfile.go
@@ -4,7 +4,14 @@ import (
 	"bufio"
 	"os"
 	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/command"
 )
+
+const specsRepoWarning = `### CocoaPods tip
+Your Podfile is still using the Specs repo. Switch to the CDN source for faster and more reliable dependency installs!
+Learn more about the one-line change [here](https://blog.cocoapods.org/CocoaPods-1.8.0-beta/).
+`
 
 // isPodfileUsingSpecsRepo returns true if the Podfile contains a source 'https://github.com/CocoaPods/Specs.git'.
 // It returns false if the CDN source or any other 3rd party git source is used.
@@ -32,4 +39,9 @@ func isPodfileUsingSpecsRepo(path string) (bool, error) {
 	}
 
 	return specsRepoDefined, nil
+}
+
+func addSpecsRepoAnnotation(cmdFactory command.Factory) {
+	cmd := cmdFactory.Create("bitrise", []string{":annotations", "annotate", specsRepoWarning, "--style", "info"}, nil)
+	_ = cmd.Run() // ignore error, this is best-effort
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The on-disk Cocoapods Specs repo needs constant updates (git pulls) to keep Cocoapods fast when the `Podfile` uses the Specs repo. Since 2019, the CDN source is the default for new `pod init`s, but there are still many projects using Podfiles referring to the Specs repo.

We want to eventually remove the on-disk Specs repo, but before that, we need more users to migrate their Podfiles.

### Changes

Create a build annotation when Specs repo usage is detected:

<img width="925" alt="image" src="https://github.com/bitrise-steplib/steps-cocoapods-install/assets/1694986/a8d03077-a925-4c25-b56c-9fc14d6a7c89">

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

This is an info level annotation for now, but we might turn it into a warning later.
