### PR TITLE
Bump e2e Ruby pin off EOL 3.2.0, fix bigdecimal LoadError

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -55,18 +55,18 @@ workflows:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
     - TEST_APP_BRANCH: main
     - COMMAND: install
-    - PIN_ASDF_RUBY: 3.4.10
+    - PIN_ASDF_RUBY: 3.4.8
     after_run:
     - _run
     - _check_cache_include_paths
 
-  # previous test isntalled required ruby version
+  # previous test installed required ruby version
   test_with_specific_installed_ruby_rbenv:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
     - TEST_APP_BRANCH: main
     - COMMAND: install
-    - PIN_RBENV_RUBY: 3.4.10
+    - PIN_RBENV_RUBY: 3.4.8
     after_run:
     - _run
     - _check_cache_include_paths

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -75,7 +75,7 @@ workflows:
     envs:
     # With Gemfile:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-apps-ios-cocoapods-plugins.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: bb/dep_mismatch
     - COMMAND: install
     after_run:
     - _run

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -55,7 +55,7 @@ workflows:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
     - TEST_APP_BRANCH: main
     - COMMAND: install
-    - PIN_ASDF_RUBY: 3.2.0
+    - PIN_ASDF_RUBY: 3.4.10
     after_run:
     - _run
     - _check_cache_include_paths
@@ -66,7 +66,7 @@ workflows:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
     - TEST_APP_BRANCH: main
     - COMMAND: install
-    - PIN_RBENV_RUBY: 3.2.0
+    - PIN_RBENV_RUBY: 3.4.10
     after_run:
     - _run
     - _check_cache_include_paths

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -23,7 +23,7 @@ workflows:
     envs:
     # With Only Gemfile (no Podfile.lock):
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
-    - TEST_APP_BRANCH: e2e/gemfile-no-podfile-lock
+    - TEST_APP_BRANCH: bb/gemfile-no-podfile-lock
     - COMMAND: install
     after_run:
     - _run
@@ -33,7 +33,7 @@ workflows:
     envs:
     # With Gemfile:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
-    - TEST_APP_BRANCH: e2e/gemfile-podfile-lockfiles
+    - TEST_APP_BRANCH: bb/gemfile-podfile-lockfiles
     - COMMAND: update
     after_run:
     - _run
@@ -43,7 +43,7 @@ workflows:
     envs:
     # With Gemfile:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
-    - TEST_APP_BRANCH: main
+    - TEST_APP_BRANCH: bb/dep_mismatch
     - COMMAND: install
     - VERBOSE: "true"
     after_run:
@@ -75,7 +75,7 @@ workflows:
     envs:
     # With Gemfile:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-apps-ios-cocoapods-plugins.git
-    - TEST_APP_BRANCH: bb/dep_mismatch
+    - TEST_APP_BRANCH: master
     - COMMAND: install
     after_run:
     - _run

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -23,7 +23,7 @@ workflows:
     envs:
     # With Only Gemfile (no Podfile.lock):
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
-    - TEST_APP_BRANCH: bb/gemfile-no-podfile-lock
+    - TEST_APP_BRANCH: e2e/gemfile-no-podfile-lock
     - COMMAND: install
     after_run:
     - _run
@@ -33,7 +33,7 @@ workflows:
     envs:
     # With Gemfile:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
-    - TEST_APP_BRANCH: bb/gemfile-podfile-lockfiles
+    - TEST_APP_BRANCH: e2e/gemfile-podfile-lockfiles
     - COMMAND: update
     after_run:
     - _run
@@ -43,7 +43,7 @@ workflows:
     envs:
     # With Gemfile:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample.git
-    - TEST_APP_BRANCH: bb/dep_mismatch
+    - TEST_APP_BRANCH: main
     - COMMAND: install
     - VERBOSE: "true"
     after_run:


### PR DESCRIPTION
## Summary
- e2e's `PIN_ASDF_RUBY`/`PIN_RBENV_RUBY` was hardcoded to Ruby 3.2.0, which is EOL. 
- was failing to build ruby 3.2 on edge stack [example](https://app.bitrise.io/app/48fa8fbee698622c/build/cf6ef213-e4dc-47cb-b163-120fa253d5a2)
- Bumped to 3.4.8, the newest version confirmed installable (via `asdf list-all ruby`) across all currently-tested stacks